### PR TITLE
fix: add `lib` to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "name": "display-shortcuts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Displays a list of keyboard shortcuts you can use on the command line and their descriptions in your terminal.",
   "license": "MIT",
   "repository": "distilledhype/display-shortcuts",
   "author": "Kahlil Lechelt <hello@kahlil.info> (http://kahlil.info)",
-  "contributors": ["André Ruffert (http://andreruffert.com)"],
+  "contributors": [
+    "André Ruffert (http://andreruffert.com)"
+  ],
   "engines": {
     "node": ">=0.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "files": [
     "index.js",
     "cli.js",
-    "shortcuts.json"
+    "shortcuts.json",
+    "lib"
   ],
   "preferGlobal": true,
   "bin": {


### PR DESCRIPTION
@distilledhype OMG! We forgot to add `lib` to the `package.json`.
At the moment it doesn't exist after installation and throws an error:

`Cannot find module './lib/assignShortcuts'`

This commit fixes the error.

![bildschirmfoto 2015-06-16 um 00 45 29](https://cloud.githubusercontent.com/assets/464300/8172495/5ed77ba6-13c1-11e5-86ce-430d1689b10c.png)
